### PR TITLE
Move nginx installation to Base Dockerfile

### DIFF
--- a/development_setup/docker-compose.yml
+++ b/development_setup/docker-compose.yml
@@ -6,11 +6,10 @@ services:
     ports:
       - "8000-8005:8000-8005"   #webserver_port
       - "9000-9005:9000-9005"   #socketio_port
-      - "6787:6787"   #file_watcher_port
+      - "6787:6787"                     #file_watcher_port
       - "3306-3307:3306-3307"   #mysql _port
     volumes:
       - ./data/bench/apps:/home/frappe/bench/apps
       - ./data/bench/sites:/home/frappe/bench/sites
-
     stdin_open: true
     tty: true

--- a/development_setup/frappe-docker-conf/init.sh
+++ b/development_setup/frappe-docker-conf/init.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
 
-# turn on debug mode
-set -x
+# turn on debug mode > https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euxo pipefail
 
-echo "----------------------- [ change sites and apps folder to it's original folder ] ---------------------------------"
-
+# change sites and apps folder to it's original folder
 sudo mv ./sites-dev/* ./sites/
 sudo mv ./apps-dev/* ./apps/
 
-sudo chown frappe sites
-sudo chown frappe apps
+# change sites and apps folder to it's original folder
+sudo chown frappe:frappe sites
+sudo chown frappe:frappe apps
 
+# patch sites data
 bench update --patch
-
-# turn off debug mode
-set +x
-
-echo "-"
-echo "-"
-echo "-"
-echo "----------------------- [ DONE! ] ---------------------------------"
-
-

--- a/docs/setup/development_setup.md
+++ b/docs/setup/development_setup.md
@@ -49,7 +49,6 @@ so you could explore the code.
 
     `docker exec -it <frappe_container_id> bash`
 
-
 * Start development server
 
     `bench start`

--- a/docs/setup/trial_setup.md
+++ b/docs/setup/trial_setup.md
@@ -15,30 +15,32 @@ it will run pre-build docker image from Docker hub.
 
 * Run latest erpnext_debian image from pipech Docker hub
 
-    `docker run -it --name <container_name> -p 8000-8005:8000-8005 -p 9000-9005:9000-9005 -p 3306-3307:3306-3307 pipech/erpnext-docker-debian:stable bash`
-
-* Start mysql
-
-    `sudo service mysql start`
-
-* Start development server
-
-    `bench start`
+    `docker run -d -p 8000-8005:8000-8005 -p 9000-9005:9000-9005 -p 3306-3307:3306-3307 pipech/erpnext-docker-debian:stable`
 
 * Go to web browser and access ERPNext
 
     `http://localhost:8000`
 
+### Start, Stop Container
+
+* Find frappe container id
+
+    `docker ps -a`
+    
+* Stop container
+
+    `docker stop <frappe_container_id>`
+    
+* Start container
+
+    `docker start <frappe_container_id>`
+
 ### Clean-up
 
-* Stop development server, press ctrl +c in terminal
+* Find frappe container id
 
-    `ctrl + c`
-
-* Exit from container
-
-    `exit`
+    `docker ps -a`
 
 * Remove container
 
-    `docker rm -f <container_name>`
+    `docker rm -f <frappe_container_id>`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+sudo service mysql start
+bench start

--- a/production_setup/Dockerfile
+++ b/production_setup/Dockerfile
@@ -38,12 +38,6 @@ WORKDIR /home/$systemUser/$benchFolderName
 # copy config
 ADD conf/frappe-docker-conf/common_site_config_docker.json ./sites/common_site_config.json
 
-# install
-RUN sudo apt-get -y update \
-    && sudo apt-get -y install \
-    nginx \
-    gettext-base
-
 # copy conf
 ADD conf/frappe-docker-conf/supervisor.conf /etc/supervisor/conf.d/supervisor.conf
 ADD conf/frappe-docker-conf/nginx.temp /etc/nginx/conf.d/nginx.temp


### PR DESCRIPTION
1. move nginx installation from production Dockerfile to base Dockerfile
2. cleanup base Dockerfile, Trail and development setup readme

We don't need to create production image.
At first I thought we need to empty sites and logs folder before we re-deploy container, it appear we don't need to empty those folder.

Because of docker volume mechanism

If volume is empty 
- it will copy content from container to volumes

If volume is not empty
- it will mount volumes to container

So there are no need to maintain 2 image.

Production Dockerfile will become template to install custom app for those who have one.
